### PR TITLE
Update font name for pre.verse in css/joel.css

### DIFF
--- a/css/joel.css
+++ b/css/joel.css
@@ -26,7 +26,7 @@ div.poem {
 
 /* *** */
 pre.verse {
-  font-family: ETBembo, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
+  font-family: et-book, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
 	margin: 1.5em auto;
 	width: auto;
     display:table;


### PR DESCRIPTION
`ETBembo` was renamed to `et-book` a while ago, but this instance was left out.
